### PR TITLE
Add the name attribute for Riley compatibility.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name              "mysql"
 maintainer        "Opscode, Inc."
 maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"


### PR DESCRIPTION
The new version of Riley being used by berkshelf requires the name attribute in metadata.rb files.
